### PR TITLE
Fix hand end condition flag value

### DIFF
--- a/holdem/env.py
+++ b/holdem/env.py
@@ -227,7 +227,7 @@ class TexasHoldemEnv(Env, utils.EzPickle):
       self._resolve(players)
 
     terminal = False
-    if self._round == 4:
+    if self._round == 4 or len(players) == 1:
       terminal = True
       self._resolve_round(players)
     return self._get_current_step_returns(terminal)


### PR DESCRIPTION
In the check that determines whether a given poker hand has been concluded, the number of players remaining in the game was not considered. Check if there is exactly one player remaining in the hand; in this case he is the winner of the given hand.

Closes #5.