### PR TITLE
Eliminate ignored extra moves during betting rounds

### DIFF
--- a/holdem/env.py
+++ b/holdem/env.py
@@ -223,7 +223,7 @@ class TexasHoldemEnv(Env, utils.EzPickle):
         # break if a single player left
         if len(players) == 1:
           self._resolve(players)
-    else:
+    if all([player.playedthisround for player in players]):
       self._resolve(players)
 
     terminal = False


### PR DESCRIPTION
In the current state, completing betting rounds exactly one more round than is required. For instance, let's say there are three players, Alice, Bob and Charlie.

* In the first move, Alice bets 50
* In the second move, Bob calls
* In the third move, Charlie also calls

Currently, for the betting round to conclude, a fourth move needs to be performed by Alice. However, its results are being discarded, as the betting resolution code checks the `playedthisround` flag and determines that the move should not be performed. This leads to unnatural and meaningless additional moves that do not normally occur in a poker game.

Eliminate the need for the additional move by checking whether all players have played the round after performing each move. If so, the betting round is resolved. Note that this does not break raising,
since a player raising clears all the other players' `playedthisround` flag.