### PR TITLE
Sit out player if below big blind

### DIFF
--- a/holdem/env.py
+++ b/holdem/env.py
@@ -338,6 +338,9 @@ class TexasHoldemEnv(Env, utils.EzPickle):
       if not p.emptyplayer and p.sitting_out:
         p.sitting_out = False
         p.playing_hand = True
+      if p.stack < self._bigblind:
+        p.sitting_out = True
+        p.playing_hand = False
 
   def _resolve_sidepots(self, players_playing):
     players = [p for p in players_playing if p.currentbet]


### PR DESCRIPTION
Right now if a player falls below BB, the loop gets stuck, sitting out the player resolves that.

Also, should probably have an optional parameter if we want to replace that player with a new player, but this would probably require some discussion